### PR TITLE
chore: ease electron dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ts-pattern": "^5.5.0"
   },
   "peerDependencies": {
-    "electron": "^31"
+    "electron": ">=31"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",


### PR DESCRIPTION
Make the electron dependency pretty liberal and open to new versions. We'll need to keep an eye out for breaking changes in the upstream electron releases and adjust this if any come along.

(cherry picked from commit e6d77c93672d385ee1b3425289ec9682731e9366)

applies to #1