### PR TITLE
fix: subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
     "url": "https://github.com/3fv/electron-utility-process-manager/issues"
   },
   "homepage": "https://github.com/3fv/electron-utility-process-manager#readme",
-  "type": "commonjs",
-  "main": "./lib/cjs/index.js",
-  "module": "./lib/mjs/index.js",
-  "types": "./lib/mjs/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib/mjs/index.d.ts",
@@ -38,6 +34,22 @@
       "node": "./lib/cjs/node/index.js",
       "import": "./lib/mjs/node/index.js",
       "require": "./lib/cjs/node/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "node": [
+        "./lib/cjs/node/index.d.ts"
+      ],
+      "main": [
+        "./lib/cjs/main/index.d.ts"
+      ],
+      "renderer": [
+        "./lib/cjs/renderer/index.d.ts"
+      ],
+      "common": [
+        "./lib/cjs/common/index.d.ts"
+      ]
     }
   },
   "scripts": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -9,13 +9,8 @@ const scriptDir = import.meta.dirname
 const rootDir = Path.resolve(scriptDir, "..")
 const libDir = Path.join(rootDir, "lib")
 const libExamplesDir = Path.join(rootDir, "lib-examples-cjs")
-const cjsDir = Path.join(libDir, "cjs")
-const mjsDir = Path.join(libDir, "mjs")
 
 Sh.rm("-rf", libDir, libExamplesDir)
-
-const cjsJsonFile = Path.join(cjsDir, "package.json")
-const mjsJsonFile = Path.join(mjsDir, "package.json")
 
 const rawArgv = process.argv.slice(2)
 
@@ -31,7 +26,7 @@ const die = (msg, exitCode = 1, err = null) => {
       err.toString()
     }
   }
-  
+
   echo`ERROR: ${msg}`
   process.exit(exitCode)
 }
@@ -46,32 +41,6 @@ const run = (...args) => {
     )
   )
 }
-
-Sh.mkdir("-p", mjsDir, cjsDir)
-
-const cjsJson = `{
-    "type": "commonjs",
-    "main": "./index.js",
-    "module": "./index.js"
-}`, mjsJson = `{
-    "type": "module",
-    "main": "./index.js",
-    "module": "./index.js"
-}`
-
-// "exports": {
-//   ".": {
-//     "types": "./index.d.ts",
-//       "default": "./index.js"
-//   },
-//   "./appenders/FileAppender.js": {
-//     "types": "./appenders/FileAppender.d.ts",
-//       "default": "./appenders/FileAppender.js"
-//   }
-// }
-
-Fs.outputFileSync(cjsJsonFile, cjsJson, { encoding: "utf-8" })
-Fs.outputFileSync(mjsJsonFile, mjsJson, { encoding: "utf-8" })
 
 const tscArgs = ["-b", "tsconfig.json", ...rawArgv, "--preserveWatchOutput"]
 


### PR DESCRIPTION
- the package.json files in each of /lib/cjs and lib/mjs were masking out the exports in the base package.json. they're not necessary. node will treat .mjs and .cjs correctly without the need to specify type: in the additional package.json files.

- added typedVersions for people using projects with tsconfig moduleResolution: "node", ts doesn't look at exports in package.json until >= node16

- there is no need to explicitily remove and recreate the cjs and mjs directories. tsc will create them if they're not there.

applies to #2 